### PR TITLE
Specify encoding explicitly

### DIFF
--- a/lib/faker/okinawa/odic.rb
+++ b/lib/faker/okinawa/odic.rb
@@ -28,7 +28,7 @@ module Faker
       end
 
       def initialize(odic_path)
-        entry_lines = File.readlines(odic_path).reject {|line|
+        entry_lines = File.readlines(odic_path, encoding: 'utf-8').reject {|line|
           line =~ COMMENT_OR_BLANK_REGEXP
         }
         @entries = entry_lines.map {|entry_line|


### PR DESCRIPTION
Since I could not use this fantastic gem on Japanese Windows, I made this pull request.
On windows, this gem shows errors when requiring this gem because ruby assumes the dic files are encoded with windows31J.